### PR TITLE
Add clickhouse 23.3

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,6 +141,15 @@ IMAGES = (
     Image(
         registry='registry-1.docker.io',
         source='altinity/clickhouse-server',
+        tag='23.3.13.7.altinitystable',
+        digests=(
+            'sha256:47f8f6b809643f4f7810ed1fb26823b1132d4a786d8aaf1d3e8fe978882acdd4',  # noqa: E501
+            'sha256:88f698ffe335c45ed4825e2fdf758c4383c5a17731e83e4fb6ee347f57cd7eb2',  # noqa: E501
+        ),
+    ),
+    Image(
+        registry='registry-1.docker.io',
+        source='altinity/clickhouse-server',
         tag='23.8.8.21.altinitystable',
         digests=(
             'sha256:0a2c4b9cc0bb16fd67f59329a96b7241d96ab003b8825236e341007850848fe6',  # noqa: E501


### PR DESCRIPTION
I thought we could go right from `22.8` to `23.8` (so I only added `23.8` in https://github.com/getsentry/image-mirror/pull/18) BUT it turns out ClickHouse had other plans for us:

Per release notes for [Altinity 23.8](https://docs.altinity.com/releasenotes/altinity-stable-release-notes/23.8/altinity-stable-23.8.8/#upgrade-notes):

> Upgrading from 20.3 and older to 22.9 and newer should be done through an intermediate version if there are any ReplicatedMergeTree tables; otherwise, the server with the new version will not start. [#40641](https://github.com/ClickHouse/ClickHouse/pull/40641). Here is a possible upgrade path if you are upgrading from 20.3: 20.3 -> 22.8 -> 23.3 -> 23.8

> If you upgrade from versions prior to 22.9, you should either upgrade all replicas at once or disable compress_marks and compress_primary_key merge tree settings before upgrade, or upgrade through an intermediate version, where the compressed marks are supported but not enabled by default, such as 23.3.

> Downgrading from 23.8 to version 23.5 or below may fail due to changes in sparse columns serialization, see [#55153](https://github.com/ClickHouse/ClickHouse/issues/55153) for possible workaround.
