### PR TITLE
update digests to point from postgres 14.9 to 14.11

### DIFF
--- a/main.py
+++ b/main.py
@@ -212,8 +212,8 @@ IMAGES = (
         source='library/postgres',
         tag='14-alpine',  # 14.11
         digests=(
-            'sha256:36ac395a179b1a85d528670839d9e5787a690ec672ee9ff087ada5ddd8db798a',  # noqa: E501
-            'sha256:36ac395a179b1a85d528670839d9e5787a690ec672ee9ff087ada5ddd8db798a',  # noqa: E501
+            'sha256:72b17e06ac53e62495270c850c1dd289580fca05491bcac45cd43c0c8047b6ef',  # noqa: E501
+            'sha256:ac4ca373551069f5cceb157bc4ba7fefc67069f3cf7dfb96fa3fbfece9888d5f',  # noqa: E501
         ),
     ),
     Image(

--- a/main.py
+++ b/main.py
@@ -210,10 +210,10 @@ IMAGES = (
     Image(
         registry='registry-1.docker.io',
         source='library/postgres',
-        tag='14-alpine',
+        tag='14-alpine',  # 14.11
         digests=(
-            'sha256:8dc41c1f358669e2006559bc817cd7c1daaa328d1ee8370ac209167f3b6a894f',  # noqa: E501
-            'sha256:583063ce031a46cdff262cdd88f22c15a829ce5814957946ccfdf20ef66d2de6',  # noqa: E501
+            'sha256:36ac395a179b1a85d528670839d9e5787a690ec672ee9ff087ada5ddd8db798a',  # noqa: E501
+            'sha256:36ac395a179b1a85d528670839d9e5787a690ec672ee9ff087ada5ddd8db798a',  # noqa: E501
         ),
     ),
     Image(


### PR DESCRIPTION
The current mirrored postgres 14-alpine image is at version 14.9, containing some vulnerabilities with known patches. 

I've updated the digests to point to the latest `14-alpine` tag, which is 14.11 and is fully patched.