### PR TITLE
ref(clickhouse): add 23.8.11.29

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,6 +167,15 @@ IMAGES = (
     ),
     Image(
         registry='registry-1.docker.io',
+        source='altinity/clickhouse-server',
+        tag='23.8.8.21.altinitystable',
+        digests=(
+            'sha256:0a2c4b9cc0bb16fd67f59329a96b7241d96ab003b8825236e341007850848fe6',  # noqa: E501
+            'sha256:73b0e574accaca6cfdb80fa20ce56574a061bc33e597d7c676b27d9c030ae485',  # noqa: E501
+        ),
+    ),
+    Image(
+        registry='registry-1.docker.io',
         source='checkr/flagr',
         tag='latest',
         digests=(

--- a/main.py
+++ b/main.py
@@ -159,10 +159,10 @@ IMAGES = (
     Image(
         registry='registry-1.docker.io',
         source='altinity/clickhouse-server',
-        tag='23.8.8.21.altinitystable',
+        tag='23.8.11.29.altinitystable',
         digests=(
-            'sha256:0a2c4b9cc0bb16fd67f59329a96b7241d96ab003b8825236e341007850848fe6',  # noqa: E501
-            'sha256:73b0e574accaca6cfdb80fa20ce56574a061bc33e597d7c676b27d9c030ae485',  # noqa: E501
+            'sha256:0e08b41c13d5e2002e34d90b2ebd2a94f026e75a66610966a968396f4ec580f5',  # noqa: E501
+            'sha256:fed65767bc03b85f69496c7481ef4b7390947cbe8d0af26ba2ba6c4422416312',  # noqa: E501
         ),
     ),
     Image(


### PR DESCRIPTION
`23.8.11.29` is the added as the latest in [altinity's stable builds](https://docs.altinity.com/altinitystablebuilds/) so lets use that instead of `23.8.8.21`. I'll remove `23.8.8.21` once it's not used in CI.

Additionally `23.8.11.29` is already what we use in [self-hosted](https://github.com/getsentry/self-hosted/blob/0dabb5a4cc6dabc3e238db60c5d1afca4afcea41/docker-compose.yml#L220).