### PR TITLE
chore(clickhouse): Add latest stable builds and remove old versions

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,93 +108,6 @@ IMAGES = (
     Image(
         registry='registry-1.docker.io',
         source='altinity/clickhouse-server',
-        tag='21.6.1.6734-testing-arm',
-        digests=(
-            'sha256:9a4516444fef9e0f11ee6b2de716d3b97b36bf05d9cc2d44c4596cfb0584dea6',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='21.8.13.1.altinitystable',
-        digests=(
-            'sha256:125d2ea49c298515c46784d202a2bd4dde05157c85a76517afc2567f262ab335',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='22.3.15.34.altinitystable',
-        digests=(
-            'sha256:5a67ec149acc13e3d87ed1e3b94b4ada6f0acdc75145724959bbd8c0a6f18410',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='22.8.15.25.altinitystable',
-        digests=(
-            'sha256:99d52fc10915136234a3b902b16d53f0ee80cd4f9149064acc30c89e54d06cf9',  # noqa: E501
-            'sha256:2935d3849fcdf3c9a24883522630758a6f017c7b48a252f6e54e8fc188ccd0cc',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='23.3.13.7.altinitystable',
-        digests=(
-            'sha256:47f8f6b809643f4f7810ed1fb26823b1132d4a786d8aaf1d3e8fe978882acdd4',  # noqa: E501
-            'sha256:88f698ffe335c45ed4825e2fdf758c4383c5a17731e83e4fb6ee347f57cd7eb2',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='23.3.19.33.altinitystable',
-        digests=(
-            'sha256:6cc967d9474eea8c92c765b177b886ee6789d59d041d58ce5bfb4b3e79f0ad73',  # noqa: E501
-            'sha256:10c02dc8e418ec9de8b71718846d45d43fb1b74225b936d9a695fe1bdac737d3',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='23.8.8.21.altinitystable',
-        digests=(
-            'sha256:0a2c4b9cc0bb16fd67f59329a96b7241d96ab003b8825236e341007850848fe6',  # noqa: E501
-            'sha256:73b0e574accaca6cfdb80fa20ce56574a061bc33e597d7c676b27d9c030ae485',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='23.8.11.29.altinitystable',
-        digests=(
-            'sha256:0e08b41c13d5e2002e34d90b2ebd2a94f026e75a66610966a968396f4ec580f5',  # noqa: E501
-            'sha256:fed65767bc03b85f69496c7481ef4b7390947cbe8d0af26ba2ba6c4422416312',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='23.8.16.43.altinitystable',
-        digests=(
-            'sha256:1b43b4f2d5f18071cf5830f4f4d30edb85726d57c667ca3219dc741b3eca9f4e',  # noqa: E501
-            'sha256:168ccfe5080f4bd0a2047cb0e07f6a4d495501b8d2b121a3919cdad47d1baea8',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
-        tag='24.3.5.47.altinitystable',
-        digests=(
-            'sha256:cf1b96e3f3ad04a3888890070585bef3c6d1afe367f3a60515662add8b66823d',  # noqa: E501
-            'sha256:abb79827bb0b10100e072c767fe2bb99f25249100020bbe0565fc75e71a78af0',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='altinity/clickhouse-server',
         tag='24.8.11.51285.altinitystable',
         digests=(
             'sha256:65b4fed146dd9fa4fc7b0eff17adbeb3c1eb3e5d3c37fc2f635913eafc22b7a5',  # noqa: E501
@@ -217,6 +130,24 @@ IMAGES = (
         digests=(
             'sha256:61139339f342ffec40111497eaf3ccb124c724c2c6dc6a1cf9ed9897aa8e0293',  # noqa: E501
             'sha256:779e5d1b07e776652c8ae96af3596bc11021ec155d0e3aa6289fd739b4f85ae1',  # noqa: E501
+        ),
+    ),
+    Image(
+        registry='registry-1.docker.io',
+        source='altinity/clickhouse-server',
+        tag='25.3.8.10041.altinitystable',
+        digests=(
+            'sha256:ae31c277673ca04facee2a2812f57ec097a53028c2eef3810968faabe752f8c3',  # noqa: E501
+            'sha256:fe43c34d28a7f1d9b539de2cec158bc5dac3c3bb6f6e2dda0963728f327db06e',  # noqa: E501
+        ),
+    ),
+    Image(
+        registry='registry-1.docker.io',
+        source='altinity/clickhouse-server',
+        tag='25.8.16.10001.altinitystable',
+        digests=(
+            'sha256:27341ab1d7988babfa011933d94c8531b2cb6b1cace7b6813ded7470b4b6e074',  # noqa: E501
+            'sha256:d880b9caff968d7530161670a5665decb0b5cf1dd40f75efe80a80c8145f68d5',  # noqa: E501
         ),
     ),
     Image(
@@ -331,14 +262,6 @@ IMAGES = (
         digests=(
             'sha256:5bb4da6e91eeaeecc693289bcc5fa91c46dc68b3b128e878bb7d2a221ad65c3b',  # noqa: E501
             'sha256:22fbd63c5b7480c584fe6f3408e92cad01e2d1c2b47128e680146ce9a2500d52',  # noqa: E501
-        ),
-    ),
-    Image(
-        registry='registry-1.docker.io',
-        source='yandex/clickhouse-server',
-        tag='20.3.9.70',
-        digests=(
-            'sha256:932ef73994dd4b6507a55a288c5ee065aae8e77e61ee569512a76a65eddbe2c3',  # noqa: E501
         ),
     ),
 )


### PR DESCRIPTION
Add the latest Altinity ClickHouse stable builds (25.3.8 and 25.8.16) and
remove all versions older than 24.8, which are no longer needed.

**Added:**
- `25.3.8.10041.altinitystable` (latest 25.3 stable)
- `25.8.16.10001.altinitystable` (new 25.8 stable line)

**Removed:**
- `yandex/clickhouse-server:20.3.9.70`
- `altinity/clickhouse-server` versions: 21.6, 21.8, 22.3, 22.8, 23.3 (×2), 23.8 (×3), 24.3


Agent transcript: https://claudescope.sentry.dev/share/Nxqvsz_Imig067U0JD-qvINLM9O93WszzDZTFzOoiTA